### PR TITLE
[Auth] Restrict pages access

### DIFF
--- a/components/NavBar/NavBar.tsx
+++ b/components/NavBar/NavBar.tsx
@@ -4,8 +4,10 @@ import logoSrc from "../../public/logo.png";
 import Image from "next/image";
 import UserAccount from "../UserAccount/UserAccount";
 import { useRouter } from "next/router";
+import { useAuth } from "../../lib/auth";
 
 export default function NavBar() {
+  const user = useAuth();
   const router = useRouter()
   return (
     <div className="w-full min-h-[76px] relative z-50">
@@ -19,7 +21,14 @@ export default function NavBar() {
       <Image
         src={logoSrc}
         alt="frens Logo"
-        className="absolute left-[calc(50%-40px/2+3px)] top-[calc(50%-40px/2+2px)]"
+        className="absolute left-[calc(50%-40px/2+3px)] top-[calc(50%-40px/2+2px)] cursor-pointer"
+        onClick={() => {
+          if(user.user) {
+            router.push('/clubs')
+          } else {
+            router.push('/');
+          }
+        }}
       />
       <div className="absolute top-[calc(50%-38px/2)] right-4">
         <UserAccount/>

--- a/components/UserAccount/AccountButton.tsx
+++ b/components/UserAccount/AccountButton.tsx
@@ -7,7 +7,6 @@ import { signInMessage } from "../../lib/ethereum";
 import { signInWithCustomToken } from "firebase/auth";
 import { firebaseClientAuth } from "../../firebase/firebaseClient";
 import { useAuth } from "../../lib/auth";
-import { useRouter } from "next/router";
 
 interface IAccountButtonProps {
   onClick?: (e: any) => void;
@@ -21,7 +20,6 @@ export default function AccountButton({
 }: IAccountButtonProps) {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
 
   const handleLogin = async (e: any) => {
     e.preventDefault();
@@ -70,7 +68,6 @@ export default function AccountButton({
     try {
       const userCred = await signInWithCustomToken(firebaseClientAuth, token);
       setLoading(false);
-      router.push('/clubs')
     } catch (err) {
       console.log(err);
       setLoading(false);

--- a/components/UserAccount/UserAccount.tsx
+++ b/components/UserAccount/UserAccount.tsx
@@ -10,7 +10,6 @@ import { signOut } from "firebase/auth";
 import { firebaseClientAuth } from "../../firebase/firebaseClient";
 import defaultProfilePic from '../../public/default_avatar.png'
 import { StaticImageData } from "next/image";
-import { useRouter } from "next/router";
 
 export default function UserAccount() {
   const { user } = useAuth();
@@ -18,7 +17,6 @@ export default function UserAccount() {
   const [walletAddress, setWalletAddress] = useState<string>("");
   const [profilePicUrl, setProfilePicUrl] = useState<string | StaticImageData>(defaultProfilePic);
   const [tooltip, setTooltip] = useState("Copy wallet address");
-  const router = useRouter();
 
   useEffect(() => {
     if (user) {
@@ -43,7 +41,6 @@ export default function UserAccount() {
         throw err;
       }
       setExpand(false);
-      router.push('/clubs');
     });
   };
 

--- a/layout/AppLayout.tsx
+++ b/layout/AppLayout.tsx
@@ -1,11 +1,27 @@
-import React from 'react'
-import NavBar from '../components/NavBar/NavBar'
+import { useRouter } from "next/router";
+import React, { useEffect } from "react";
+import NavBar from "../components/NavBar/NavBar";
+import { useAuth } from "../lib/auth";
 
-export default function AppLayout({children}: {children: React.ReactNode}) {
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const user = useAuth();
+  const router = useRouter();
+  useEffect(() => {
+    router.replace({ pathname: router.pathname, query: router.query });
+  }, [user.user]);
   return (
-    <div className='h-full w-full flex flex-col'>
-      <NavBar/>
-      <main className='grow overflow-scroll'>{children}</main>
+    <div className="h-full w-full flex flex-col">
+      <NavBar />
+      <main className="grow overflow-scroll">
+        {user.user ? (
+          children
+        ) : (
+          <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
+            <h3>Please login before continuing</h3>
+          </div>
+        )}
+        {/* {children} */}
+      </main>
     </div>
-  )
+  );
 }

--- a/pages/clubs/index.tsx
+++ b/pages/clubs/index.tsx
@@ -1,11 +1,10 @@
-import React, { ReactElement, useEffect } from "react";
+import React, { ReactElement } from "react";
 import AppLayout from "../../layout/AppLayout";
 import { useRouter } from "next/router";
 import { useAuth } from "../../lib/auth";
 import { NextPageWithLayout } from "../_app";
 import { Button } from "../../components/Button/Button";
 import ClubCard from "../../components/ClubCard/ClubCard";
-import defaultImg from "../../public/default_club.png";
 import nookies from "nookies";
 import { firebaseAdmin } from "../../firebase/firebaseAdmin";
 import { InferGetServerSidePropsType } from "next";
@@ -113,44 +112,40 @@ const ClubList: NextPageWithLayout<any> = (
   return (
     <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
       <div className="flex flex-col gap-6 md:gap-8 max-w-[1000px] mx-auto">
-        {user.user ? (
-          <>
-            {/* Title and create button for desktop */}
-            <div className="flex flex-row items-start justify-between w-full">
-              <h1>My clubs</h1>
+        {/* Title and create button for desktop */}
+        <div className="flex flex-row items-start justify-between w-full">
+          <h1>My clubs</h1>
+          <Button
+            className="w-[218px] hidden md:block"
+            onClick={() => router.push("/create")}
+          >
+            <h3>Create new club</h3>
+          </Button>
+        </div>
+        {/* Club cards */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 w-full justify-items-center">
+          {serverProps.clubData && (
+            <>
+              {serverProps.clubData.map((club, index) => {
+                return (
+                  <ClubCard
+                    key={index}
+                    clubName={club.club_name}
+                    clubDes={club.club_description}
+                    profileImgUrl={club.club_image}
+                    onClick={() => router.push(`/clubs/${club.club_id}`)}
+                  />
+                );
+              })}
               <Button
-                className="w-[218px] hidden md:block"
+                className="w-[218px] block md:hidden mb-6"
                 onClick={() => router.push("/create")}
               >
                 <h3>Create new club</h3>
               </Button>
-            </div>
-            {/* Club cards */}
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 w-full justify-items-center">
-              {serverProps.clubData && (
-                <>
-                  {serverProps.clubData.map((club, index) => {
-                    return (
-                      <ClubCard
-                        key={index}
-                        clubName={club.club_name}
-                        clubDes={club.club_description}
-                        profileImgUrl={club.club_image}
-                        onClick={() => router.push(`/clubs/${club.club_id}`)}
-                      />
-                    );
-                  })}
-                  <Button
-                    className="w-[218px] block md:hidden mb-6"
-                    onClick={() => router.push("/create")}
-                  >
-                    <h3>Create new club</h3>
-                  </Button>
-                </>
-              )}
-            </div>
-          </>
-        ) : <h3>You need to login to see all your clubs</h3>}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## PR Overview
For club list, club dashboard and club creation pages, only users who have authenticated should be able to access. I have set the restriction logic in `AppLayout` shared by all these restricted pages, to not render its children if the user is not authed.

This method is for Capstone demo purposes. For the actual application, I still need to:
- [ ] Restrict access of club dashboards that the user do not have tokens for
- [ ] Restrict access of club creation step pages that the user did not start
- [ ] Styling for the "Not authorized" page