### PR TITLE
[Auth] Fix page flash when reloading page

### DIFF
--- a/components/ClubDetails/ClubDetails.tsx
+++ b/components/ClubDetails/ClubDetails.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import Image from "next/image";
 import { Button } from "../Button/Button";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
-import { TClubInfo } from "../../pages/clubs/[id]";
+import { IClubInfo } from "../../pages/clubs/[id]";
 
-export default function ClubDetails({data}:{data: TClubInfo}) {
+export default function ClubDetails({data}:{data: IClubInfo}) {
   // console.log('data parsed into ClubDetails', data);
   return (
     <div className="flex flex-col items-start gap-3 w-full">

--- a/components/NotAuthed/NotAuthed.tsx
+++ b/components/NotAuthed/NotAuthed.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function NotAuthed() {
+  return (
+    <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
+      <h3>Please login before continuing</h3>
+    </div>
+  );
+}

--- a/components/UserAccount/AccountButton.tsx
+++ b/components/UserAccount/AccountButton.tsx
@@ -7,6 +7,7 @@ import { signInMessage } from "../../lib/ethereum";
 import { signInWithCustomToken } from "firebase/auth";
 import { firebaseClientAuth } from "../../firebase/firebaseClient";
 import { useAuth } from "../../lib/auth";
+import { useRouter } from "next/router";
 
 interface IAccountButtonProps {
   onClick?: (e: any) => void;
@@ -20,6 +21,7 @@ export default function AccountButton({
 }: IAccountButtonProps) {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
+  const router = useRouter()
 
   const handleLogin = async (e: any) => {
     e.preventDefault();
@@ -68,6 +70,7 @@ export default function AccountButton({
     try {
       const userCred = await signInWithCustomToken(firebaseClientAuth, token);
       setLoading(false);
+      router.replace({ pathname: router.pathname, query: router.query })
     } catch (err) {
       console.log(err);
       setLoading(false);

--- a/components/UserAccount/UserAccount.tsx
+++ b/components/UserAccount/UserAccount.tsx
@@ -10,6 +10,7 @@ import { signOut } from "firebase/auth";
 import { firebaseClientAuth } from "../../firebase/firebaseClient";
 import defaultProfilePic from '../../public/default_avatar.png'
 import { StaticImageData } from "next/image";
+import { useRouter } from "next/router";
 
 export default function UserAccount() {
   const { user } = useAuth();
@@ -17,6 +18,7 @@ export default function UserAccount() {
   const [walletAddress, setWalletAddress] = useState<string>("");
   const [profilePicUrl, setProfilePicUrl] = useState<string | StaticImageData>(defaultProfilePic);
   const [tooltip, setTooltip] = useState("Copy wallet address");
+  const router = useRouter(); 
 
   useEffect(() => {
     if (user) {
@@ -41,6 +43,7 @@ export default function UserAccount() {
         throw err;
       }
       setExpand(false);
+      router.replace({ pathname: router.pathname, query: router.query })
     });
   };
 

--- a/layout/AppLayout.tsx
+++ b/layout/AppLayout.tsx
@@ -6,21 +6,21 @@ import { useAuth } from "../lib/auth";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const user = useAuth();
   const router = useRouter();
-  useEffect(() => {
-    router.replace({ pathname: router.pathname, query: router.query });
-  }, [user.user]);
+  // useEffect(() => {
+  //   router.replace({ pathname: router.pathname, query: router.query });
+  // }, [user.user]);
   return (
     <div className="h-full w-full flex flex-col">
       <NavBar />
       <main className="grow">
-        {user.user ? (
+        {/* {user.user ? (
           children
         ) : (
           <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
             <h3>Please login before continuing</h3>
           </div>
-        )}
-        {/* {children} */}
+        )} */}
+        {children}
       </main>
     </div>
   );

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -203,7 +203,7 @@ export const getServerSideProps = async (context: any) => {
 const Dashboard: NextPageWithLayout<any> = ({
   ...serverProps
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  console.log(serverProps);
+  // console.log(serverProps);
   return (
     <>
       {!serverProps.error ? (

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -26,7 +26,7 @@ export interface IClubInfo {
   club_wallet_mnemonic?: string;
   deposited?: boolean;
   club_members: string[];
-};
+}
 
 export type THoldingsData = {
   token_address: string;
@@ -49,7 +49,13 @@ export const getServerSideProps = async (context: any) => {
   const cookies = nookies.get(context);
   // console.log(cookies)
   // console.log(id);
-
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  }
   // Fetch function for club information
   const fetchClubInfo = async (id: string) => {
     try {
@@ -95,10 +101,12 @@ export const getServerSideProps = async (context: any) => {
         memberInfo.push({
           display_name: _memberInfo.displayName!,
           profile_image: _memberInfo.photoURL!,
-          uid: _memberInfo.uid
+          uid: _memberInfo.uid,
         });
       })
-    ).catch((err) => {throw err});
+    ).catch((err) => {
+      throw err;
+    });
     return memberInfo;
   };
 
@@ -168,9 +176,9 @@ export const getServerSideProps = async (context: any) => {
   if (!cookies.token) {
     return {
       props: {
-        error: 'Not authed'
-      }
-    }
+        error: "Not authed",
+      },
+    };
   } else {
     try {
       const clubInfo: IClubInfo = await fetchClubInfo(id);
@@ -191,8 +199,8 @@ export const getServerSideProps = async (context: any) => {
       console.log(err);
       return {
         props: {
-          error: err
-        }
+          error: err,
+        },
       };
     }
   }
@@ -205,23 +213,27 @@ const Dashboard: NextPageWithLayout<any> = ({
   // console.log(user && user.user)
   return (
     <>
-    {!serverProps.error ? (<div className="md:max-w-[1000px] w-full md:mx-auto px-4 pt-3 md:pt-12 pb-5 h-full md:flex md:flex-row md:items-start md:gap-6 flex flex-col gap-8">
-      {/* Left panel */}
-      <div className="flex flex-col items-start gap-8 w-full">
-        {/* Club details and members */}
-        <div className="flex flex-col items-start gap-4 w-full">
-          <ClubDetails data={serverProps.clubInfo!} />
-          <ClubMembers data={serverProps.members!} />
+      {!serverProps.error ? (
+        <div className="md:max-w-[1000px] w-full md:mx-auto px-4 pt-3 md:pt-12 pb-5 h-full md:flex md:flex-row md:items-start md:gap-6 flex flex-col gap-8">
+          {/* Left panel */}
+          <div className="flex flex-col items-start gap-8 w-full">
+            {/* Club details and members */}
+            <div className="flex flex-col items-start gap-4 w-full">
+              <ClubDetails data={serverProps.clubInfo!} />
+              <ClubMembers data={serverProps.members!} />
+            </div>
+            {/* Balance */}
+            {/* TODO: have a global state setting for whether to show club or me balance */}
+            <ClubBalance />
+            {/* Portfolio */}
+            <Portfolio data={serverProps.balance!} />
+          </div>
+          {/* Right panel */}
+          <WidgetSection />
         </div>
-        {/* Balance */}
-        {/* TODO: have a global state setting for whether to show club or me balance */}
-        <ClubBalance />
-        {/* Portfolio */}
-        <Portfolio data={serverProps.balance!}/>
-      </div>
-      {/* Right panel */}
-      <WidgetSection />
-    </div>) : <NotAuthed />}
+      ) : (
+        <NotAuthed />
+      )}
     </>
   );
 };

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -203,7 +203,6 @@ export const getServerSideProps = async (context: any) => {
 const Dashboard: NextPageWithLayout<any> = ({
   ...serverProps
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  // console.log(serverProps);
   return (
     <>
       {!serverProps.error ? (

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -49,13 +49,6 @@ export const getServerSideProps = async (context: any) => {
   const cookies = nookies.get(context);
   // console.log(cookies)
   // console.log(id);
-  if (!cookies.token) {
-    return {
-      props: {
-        error: "user not authed",
-      },
-    };
-  }
   // Fetch function for club information
   const fetchClubInfo = async (id: string) => {
     try {
@@ -173,6 +166,7 @@ export const getServerSideProps = async (context: any) => {
       throw err;
     }
   };
+  
   if (!cookies.token) {
     return {
       props: {

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -13,9 +13,11 @@ import WidgetSection from "../../../components/Widgets/WidgetSection";
 import { getChainData } from "../../../lib/chains";
 import axios from "axios";
 import _ from "lodash";
+import nookies from "nookies";
+import NotAuthed from "../../../components/NotAuthed/NotAuthed";
 const TradeAsset = lazy(() => import("../../../components/Widgets/TradeAsset"));
 
-export type TClubInfo = {
+export interface IClubInfo {
   club_description: string;
   club_image: string;
   club_name: string;
@@ -44,6 +46,8 @@ export type TMemberInfoData = {
 
 export const getServerSideProps = async (context: any) => {
   const { id } = context.params;
+  const cookies = nookies.get(context);
+  // console.log(cookies)
   // console.log(id);
 
   // Fetch function for club information
@@ -58,7 +62,7 @@ export const getServerSideProps = async (context: any) => {
           if (!doc.exists) {
             throw new Error("club does not exist in database");
           }
-          return doc.data() as TClubInfo;
+          return doc.data() as IClubInfo;
         })
         .then((data) => {
           const {
@@ -94,7 +98,7 @@ export const getServerSideProps = async (context: any) => {
           uid: _memberInfo.uid
         });
       })
-    );
+    ).catch((err) => {throw err});
     return memberInfo;
   };
 
@@ -161,27 +165,36 @@ export const getServerSideProps = async (context: any) => {
       throw err;
     }
   };
-
-  try {
-    const clubInfo: TClubInfo = await fetchClubInfo(id);
-    const balance: THoldingsData[] = await fetchPortfolio(
-      clubInfo.club_wallet_address
-    );
-    const memberInfo: TMemberInfoData[] = await fetchMemberInfo(
-      clubInfo.club_members
-    );
+  if (!cookies.token) {
     return {
       props: {
-        clubInfo: clubInfo,
-        balance: balance,
-        members: memberInfo,
-      },
-    };
-  } catch (err) {
-    console.log(err);
-    return {
-      notFound: true,
-    };
+        error: 'Not authed'
+      }
+    }
+  } else {
+    try {
+      const clubInfo: IClubInfo = await fetchClubInfo(id);
+      const balance: THoldingsData[] = await fetchPortfolio(
+        clubInfo.club_wallet_address
+      );
+      const memberInfo: TMemberInfoData[] = await fetchMemberInfo(
+        clubInfo.club_members
+      );
+      return {
+        props: {
+          clubInfo: clubInfo,
+          balance: balance,
+          members: memberInfo,
+        },
+      };
+    } catch (err) {
+      console.log(err);
+      return {
+        props: {
+          error: err
+        }
+      };
+    }
   }
 };
 
@@ -189,27 +202,27 @@ const Dashboard: NextPageWithLayout<any> = ({
   ...serverProps
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   // console.log(serverProps);
-  const user = useAuth();
-  const router = useRouter();
   // console.log(user && user.user)
   return (
-    <div className="md:max-w-[1000px] w-full md:mx-auto px-4 pt-3 md:pt-12 pb-5 h-full md:flex md:flex-row md:items-start md:gap-6 flex flex-col gap-8">
+    <>
+    {!serverProps.error ? (<div className="md:max-w-[1000px] w-full md:mx-auto px-4 pt-3 md:pt-12 pb-5 h-full md:flex md:flex-row md:items-start md:gap-6 flex flex-col gap-8">
       {/* Left panel */}
       <div className="flex flex-col items-start gap-8 w-full">
         {/* Club details and members */}
         <div className="flex flex-col items-start gap-4 w-full">
-          <ClubDetails data={serverProps.clubInfo} />
-          <ClubMembers data={serverProps.members} />
+          <ClubDetails data={serverProps.clubInfo!} />
+          <ClubMembers data={serverProps.members!} />
         </div>
         {/* Balance */}
         {/* TODO: have a global state setting for whether to show club or me balance */}
         <ClubBalance />
         {/* Portfolio */}
-        <Portfolio data={serverProps.balance}/>
+        <Portfolio data={serverProps.balance!}/>
       </div>
       {/* Right panel */}
       <WidgetSection />
-    </div>
+    </div>) : <NotAuthed />}
+    </>
   );
 };
 

--- a/pages/clubs/[id]/index.tsx
+++ b/pages/clubs/[id]/index.tsx
@@ -209,8 +209,7 @@ export const getServerSideProps = async (context: any) => {
 const Dashboard: NextPageWithLayout<any> = ({
   ...serverProps
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  // console.log(serverProps);
-  // console.log(user && user.user)
+  console.log(serverProps);
   return (
     <>
       {!serverProps.error ? (

--- a/pages/clubs/index.tsx
+++ b/pages/clubs/index.tsx
@@ -8,146 +8,116 @@ import ClubCard from "../../components/ClubCard/ClubCard";
 import nookies from "nookies";
 import { firebaseAdmin } from "../../firebase/firebaseAdmin";
 import { InferGetServerSidePropsType } from "next";
+import NotAuthed from "../../components/NotAuthed/NotAuthed";
+import { IClubInfo } from "./[id]";
+
+interface IClubData extends IClubInfo {
+  club_id: string;
+}
 
 export const getServerSideProps = async (context: any) => {
   // Step 0: get auth status of the user
   const cookies = nookies.get(context);
-  const clubs = await firebaseAdmin
-    .auth()
-    .verifyIdToken(cookies.token)
-    .then(async (user) => {
-      const clubs = await firebaseAdmin
-        .firestore()
-        .collection("roles")
-        .doc(user.uid)
-        .get()
-        .then((doc) => {
-          if (!doc.exists) {
-            return {
-              props: null,
-            };
-          }
-          return doc.data();
-        })
-        .then((data) => {
-          if (!data) {
-            return {
-              props: {
-                clubData: null,
-              },
-            };
-          }
-          return data.clubs;
-        })
-        // Step 2: get all the club data
-        .then(async (clubs) => {
-          if (!clubs) {
-            return {
-              props: {
-                clubData: null,
-              },
-            };
-          }
-          const clubInfo = await Promise.allSettled(
-            clubs.map(async (clubId: string) => {
-              const clubData = await firebaseAdmin
-                .firestore()
-                .collection("clubs")
-                .doc(clubId)
-                .get()
-                .then((doc) => {
-                  return doc.data();
-                });
-              return {
-                club_id: clubId,
-                ...clubData,
-              };
-            })
-          );
-          // console.log(clubInfo);
-          const filtered = clubInfo.filter((club) => {
-            return club.status === "fulfilled" && club.value !== undefined;
-          });
-          return {
-            props: {
-              clubData: filtered.map((club) => {
-                // @ts-ignore
-                return club.value;
-              }),
-            },
-          };
-        })
-        .catch((err) => {
-          console.log(err);
-          return {
-            props: {
-              clubData: null,
-            },
-          };
-        });
-      return { ...clubs };
-    })
-    .catch((err) => {
-      console.log(err);
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  } else {
+    try {
+      const user = await firebaseAdmin.auth().verifyIdToken(cookies.token).catch(() => {throw Error('user not authed')})
+      const docSnap = await firebaseAdmin.firestore().collection('roles').doc(user.uid).get()
+      if (!docSnap.exists) {
+        throw Error('user is not in roles collection')
+      }
+      if (!docSnap.data()) {
+        throw Error('clubs not found')
+      }
+      const _clubs = docSnap.data()!.clubs;
+      const _fetchClubDataPromise = await Promise.allSettled(_clubs.map(async (clubId: string):Promise<IClubData> => {
+        const clubData = await firebaseAdmin
+          .firestore()
+          .collection("clubs")
+          .doc(clubId)
+          .get()
+          .then((doc) => {
+            return doc.data() as IClubData;
+          }).catch((err) => {throw err});
+        console.log(clubData)
+        return {
+          ...clubData,
+          club_id: clubId,
+        }
+      }));
+      const response = (_fetchClubDataPromise.filter((res) => res.status === "fulfilled" && res.value !== undefined) as PromiseFulfilledResult<IClubData>[]).map((club) => club.value)
       return {
         props: {
-          clubData: null,
-        },
+          clubData: response
+        }
       };
-    });
-  // console.log(user);
-  // Step 1: get all clubs that belongs to the user
-
-  console.log(clubs);
-  return { ...clubs };
+    } catch (err: any) {
+      return {
+        props: {
+          error: err.message
+        }
+      }
+    }
+  }
 };
 
-const ClubList: NextPageWithLayout<any> = (
-  serverProps: InferGetServerSidePropsType<typeof getServerSideProps>
-) => {
-  // console.log(serverProps)
+const ClubList: NextPageWithLayout<any> = ({
+  ...serverProps
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  // console.log(serverProps);
   const user = useAuth();
   const router = useRouter();
   // console.log(user)
   return (
-    <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
-      <div className="flex flex-col gap-6 md:gap-8 max-w-[1000px] mx-auto">
-        {/* Title and create button for desktop */}
-        <div className="flex flex-row items-start justify-between w-full">
-          <h1>My clubs</h1>
-          <Button
-            className="w-[218px] hidden md:block"
-            onClick={() => router.push("/create")}
-          >
-            <h3>Create new club</h3>
-          </Button>
-        </div>
-        {/* Club cards */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 w-full justify-items-center">
-          {serverProps.clubData && (
-            <>
-              {serverProps.clubData.map((club, index) => {
-                return (
-                  <ClubCard
-                    key={index}
-                    clubName={club.club_name}
-                    clubDes={club.club_description}
-                    profileImgUrl={club.club_image}
-                    onClick={() => router.push(`/clubs/${club.club_id}`)}
-                  />
-                );
-              })}
+    <>
+      {!serverProps.error ? (
+        <div className="h-full w-full py-8 md:py-12 px-4 md:px-6">
+          <div className="flex flex-col gap-6 md:gap-8 max-w-[1000px] mx-auto">
+            {/* Title and create button for desktop */}
+            <div className="flex flex-row items-start justify-between w-full">
+              <h1>My clubs</h1>
               <Button
-                className="w-[218px] block md:hidden mb-6"
+                className="w-[218px] hidden md:block"
                 onClick={() => router.push("/create")}
               >
                 <h3>Create new club</h3>
               </Button>
-            </>
-          )}
+            </div>
+            {/* Club cards */}
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 w-full justify-items-center">
+              {serverProps.clubData && (
+                <>
+                  {serverProps.clubData.map((club, index) => {
+                    return (
+                      <ClubCard
+                        key={index}
+                        clubName={club.club_name}
+                        clubDes={club.club_description}
+                        profileImgUrl={club.club_image}
+                        onClick={() => router.push(`/clubs/${club.club_id}`)}
+                      />
+                    );
+                  })}
+                  <Button
+                    className="w-[218px] block md:hidden mb-6"
+                    onClick={() => router.push("/create")}
+                  >
+                    <h3>Create new club</h3>
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      ) : (
+        <NotAuthed />
+      )}
+    </>
   );
 };
 

--- a/pages/create/[id]/1.tsx
+++ b/pages/create/[id]/1.tsx
@@ -6,17 +6,55 @@ import CreateProcessLayout from "../../../layout/CreateProcessLayout";
 import FeeEstimate from "../../../components/FeeEstimate/FeeEstimate";
 import { Button } from "../../../components/Button/Button";
 import { useRouter } from "next/router";
+import nookies from "nookies";
+import { InferGetServerSidePropsType } from "next";
+import NotAuthed from "../../../components/NotAuthed/NotAuthed";
 
-const StepOne: NextPageWithLayout<any> = () => {
+export const getServerSideProps = async (context: any) => {
+  const cookies = nookies.get(context);
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  } else {
+    return {
+      props: {},
+    };
+  }
+};
+
+const StepOne: NextPageWithLayout<any> = ({
+  ...serverProps
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
-  const {id} = router.query;
+  const { id } = router.query;
   return (
-    <div className="grow flex flex-col items-center gap-4 w-full">
-      <h3 className="text-center">Confirm creation fee</h3>
-      <p className=" text-center">Make sure you have enough ETH in your wallet to cover the creation fee for your club</p>
-      <FeeEstimate eth={String(process.env.NEXT_PUBLIC_CLUB_DEPOSIT)} usd={12.37} className="w-5/6 md:min-w-[296px] min-w-full"/>
-      <Button className="w-[245px]" onClick={() => router.push(`/create/${id}/2`)}><h3>Confirm and create</h3></Button>
-    </div>
+    <>
+      {!serverProps.error ? (
+        <div className="grow flex flex-col items-center gap-4 w-full">
+          <h3 className="text-center">Confirm creation fee</h3>
+          <p className=" text-center">
+            Make sure you have enough ETH in your wallet to cover the creation
+            fee for your club
+          </p>
+          <FeeEstimate
+            eth={String(process.env.NEXT_PUBLIC_CLUB_DEPOSIT)}
+            usd={12.37}
+            className="w-5/6 md:min-w-[296px] min-w-full"
+          />
+          <Button
+            className="w-[245px]"
+            onClick={() => router.push(`/create/${id}/2`)}
+          >
+            <h3>Confirm and create</h3>
+          </Button>
+        </div>
+      ) : (
+        <NotAuthed />
+      )}
+    </>
   );
 };
 
@@ -24,9 +62,7 @@ StepOne.getLayout = function getLayout(page: ReactElement) {
   return (
     <AppLayout>
       <CreateLayout>
-        <CreateProcessLayout>
-          {page}
-        </CreateProcessLayout>
+        <CreateProcessLayout>{page}</CreateProcessLayout>
       </CreateLayout>
     </AppLayout>
   );

--- a/pages/create/[id]/3.tsx
+++ b/pages/create/[id]/3.tsx
@@ -7,64 +7,94 @@ import Spinner from "../../../components/Spinner/Spinner";
 import { Button } from "../../../components/Button/Button";
 import { useRouter } from "next/router";
 import { useAuth } from "../../../lib/auth";
+import nookies from "nookies";
+import { InferGetServerSidePropsType } from "next";
+import NotAuthed from "../../../components/NotAuthed/NotAuthed";
 
-const StepThree: NextPageWithLayout<any> = () => {
+export const getServerSideProps = async (context: any) => {
+  const cookies = nookies.get(context);
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  } else {
+    return {
+      props: {},
+    };
+  }
+};
+
+const StepThree: NextPageWithLayout<any> = ({
+  ...serverProps
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<any>();
-  const router = useRouter()
-  const {id} = router.query
+  const router = useRouter();
+  const { id } = router.query;
   const user = useAuth();
 
   const handleTokenCreation = async () => {
-    await fetch('/api/create/token', {
-      method: 'POST',
+    await fetch("/api/create/token", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         clubId: String(id),
-        userId: String(user.user?.uid)
-      })
-    }).then(() => {
-      setSuccess(true);
-      setTimeout(() => router.push(`/create/${id}/complete`), 1500)
-    }).catch((err) => {
-      setError(err);
+        userId: String(user.user?.uid),
+      }),
     })
-  }
+      .then(() => {
+        setSuccess(true);
+        setTimeout(() => router.push(`/create/${id}/complete`), 1500);
+      })
+      .catch((err) => {
+        setError(err);
+      });
+  };
 
   useEffect(() => {
     handleTokenCreation();
-  }, [])
+  }, []);
 
   return (
-    <div className="grow flex flex-col items-center gap-4 w-full">
-      <Spinner success={success} error={error} />
-      {success ? (
-        <>
-          <h3 className="text-center">Your club is created!</h3>
-          <p className="text-center">
-            We will redirect you to your club in a few seconds. Get ready...
-          </p>
-        </>
-      ) : error ? (
-        <>
-          <h3 className="text-center">Fail to create club</h3>
-          <p className="text-center">
-            We have received the creation fee but have difficulty creating the
-            club. You can try creating your club again.
-          </p>
-          <Button className="w-[245px]"><h3>Create club again</h3></Button>
-        </>
+    <>
+      {!serverProps.error ? (
+        <div className="grow flex flex-col items-center gap-4 w-full">
+          <Spinner success={success} error={error} />
+          {success ? (
+            <>
+              <h3 className="text-center">Your club is created!</h3>
+              <p className="text-center">
+                We will redirect you to your club in a few seconds. Get ready...
+              </p>
+            </>
+          ) : error ? (
+            <>
+              <h3 className="text-center">Fail to create club</h3>
+              <p className="text-center">
+                We have received the creation fee but have difficulty creating
+                the club. You can try creating your club again.
+              </p>
+              <Button className="w-[245px]">
+                <h3>Create club again</h3>
+              </Button>
+            </>
+          ) : (
+            <>
+              <h3 className="text-center">Creating your club...</h3>
+              <p className="text-center">
+                This will take a few minutes. Do not close this window
+              </p>
+            </>
+          )}
+        </div>
       ) : (
-        <>
-          <h3 className="text-center">Creating your club...</h3>
-          <p className="text-center">
-            This will take a few minutes. Do not close this window
-          </p>
-        </>
+        <NotAuthed />
       )}
-    </div>
+    </>
   );
 };
 

--- a/pages/create/[id]/complete.tsx
+++ b/pages/create/[id]/complete.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps = async (context: any) => {
 const StepComplete: NextPageWithLayout<any> = (
   serverProps: InferGetServerSidePropsType<typeof getServerSideProps>
 ) => {
-  console.log(serverProps);
+  // console.log(serverProps);
   const router = useRouter();
   const { id } = router.query;
   return (

--- a/pages/create/[id]/complete.tsx
+++ b/pages/create/[id]/complete.tsx
@@ -1,47 +1,50 @@
 import React, { ReactElement } from "react";
 import { NextPageWithLayout } from "../../_app";
 import AppLayout from "../../../layout/AppLayout";
-
 import { Button } from "../../../components/Button/Button";
 import { useRouter } from "next/router";
 import { InferGetServerSidePropsType } from "next";
 import { adminFirestore } from "../../../firebase/firebaseAdmin";
-import { getDownloadURL, ref } from "firebase/storage";
-import { clientStorage } from "../../../firebase/firebaseClient";
 import Image from "next/image";
+import nookies from "nookies";
+import NotAuthed from "../../../components/NotAuthed/NotAuthed";
 
 export const getServerSideProps = async (context: any) => {
   const { id } = context.params;
+  const cookies = nookies.get(context);
   // console.log(id);
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  }
   // Step 1: fetch the information about this club
-  const res = await adminFirestore
+  try {
+    const res = await adminFirestore
     .collection("clubs")
     .doc(id)
     .get()
     .then((doc) => {
       if (!doc.exists) {
-        return {
-          notFound: true,
-        };
+        throw new Error("club does not exist");
       }
       return doc.data();
     })
-    .then((data) => {
-      return {
-        props: {
-          clubName: data!.club_name,
-          profileImgUrl: data!.club_image,
-        },
-      };
-    })
-    .catch(() => {
-      return {
-        notFound: true,
-      };
-    });
-  return {
-    ...res,
-  };
+    return {
+      props: {
+        clubName: res!.club_name,
+        profileImgUrl: res!.club_image,
+      }
+    }
+  } catch (err: any) {
+    return {
+      props: {
+        error: err.message
+      }
+    }
+  }
 };
 
 const StepComplete: NextPageWithLayout<any> = (
@@ -51,27 +54,35 @@ const StepComplete: NextPageWithLayout<any> = (
   const router = useRouter();
   const { id } = router.query;
   return (
-    // Container to center the content
-    <div className="flex flex-row items-center justify-center h-full w-full px-6">
-      <div className="flex flex-col items-center justify-center gap-4 max-w-[480px]">
-        <div className=" w-16 md:w-24 h-16 md:h-24 relative rounded-10 border-2 border-secondary-300 overflow-hidden">
-          <Image
-            src={serverProps.profileImgUrl}
-            alt={`Profile image for ${serverProps.clubName}`}
-            fill
-          />
+    <>
+      {!serverProps.error ? (
+        <div className="flex flex-row items-center justify-center h-full w-full px-6">
+          <div className="flex flex-col items-center justify-center gap-4 max-w-[480px]">
+            <div className=" w-16 md:w-24 h-16 md:h-24 relative rounded-10 border-2 border-secondary-300 overflow-hidden">
+              <Image
+                src={serverProps.profileImgUrl}
+                alt={`Profile image for ${serverProps.clubName}`}
+                fill
+              />
+            </div>
+            {/* TODO: render name of the club created */}
+            <h3 className="text-center">Welcome to {serverProps.clubName}</h3>
+            <p className="text-center">
+              In your club, you can raise money from your friends and invest
+              together in cryptocurrencies
+            </p>
+            <Button
+              className="w-[245px]"
+              onClick={() => router.push(`/clubs/${id}`)}
+            >
+              <h3>Go to club</h3>
+            </Button>
+          </div>
         </div>
-        {/* TODO: render name of the club created */}
-        <h3 className="text-center">Welcome to {serverProps.clubName}</h3>
-        <p className="text-center">
-          In your club, you can raise money from your friends and invest
-          together in cryptocurrencies
-        </p>
-        <Button className="w-[245px]" onClick={() => router.push(`/clubs/${id}`)}>
-          <h3>Go to club</h3>
-        </Button>
-      </div>
-    </div>
+      ) : (
+        <NotAuthed />
+      )}
+    </>
   );
 };
 

--- a/pages/create/index.tsx
+++ b/pages/create/index.tsx
@@ -7,11 +7,14 @@ import InputField from "../../components/InputField/InputField";
 import { Form } from "@unform/web";
 import { Button } from "../../components/Button/Button";
 import FeeEstimate from "../../components/FeeEstimate/FeeEstimate";
-import axios from 'axios';
+import axios from "axios";
 import { useRouter } from "next/router";
-import * as Yup from 'yup';
-import { SubmitHandler, FormHandles } from "@unform/core";
+import * as Yup from "yup";
+import { FormHandles } from "@unform/core";
 import { useAuth } from "../../lib/auth";
+import nookies from "nookies";
+import { InferGetServerSidePropsType } from "next";
+import NotAuthed from "../../components/NotAuthed/NotAuthed";
 
 interface IClubInfoData {
   clubName: string;
@@ -19,7 +22,24 @@ interface IClubInfoData {
   tokenSym: string;
 }
 
-const CreateClub: NextPageWithLayout<any> = () => {
+export const getServerSideProps = async (context: any) => {
+  const cookies = nookies.get(context);
+  if (!cookies.token) {
+    return {
+      props: {
+        error: "user not authed",
+      },
+    };
+  } else {
+    return {
+      props: {},
+    };
+  }
+};
+
+const CreateClub: NextPageWithLayout<any> = ({
+  ...serverProps
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
   const formRef = useRef<FormHandles>(null);
   const [clubName, setClubName] = useState("");
@@ -30,18 +50,19 @@ const CreateClub: NextPageWithLayout<any> = () => {
   const handleFormSubmit = async (data: IClubInfoData) => {
     // TODO: implement form handle logic for creating a club
 
-    setCreateLoading(true)
+    setCreateLoading(true);
 
     try {
       const schema = Yup.object().shape({
-        clubName: Yup.string().required('Club name is required'),
-        tokenSym: Yup.string().max(6, 'Token symbol cannot be more than 6 characters').required('Token symbol is required'),
+        clubName: Yup.string().required("Club name is required"),
+        tokenSym: Yup.string()
+          .max(6, "Token symbol cannot be more than 6 characters")
+          .required("Token symbol is required"),
       });
-  
+
       await schema.validate(data, {
         abortEarly: false,
       });
-
     } catch (err) {
       const validationErrors: { [key: string]: any } = {};
       if (err instanceof Yup.ValidationError) {
@@ -55,96 +76,118 @@ const CreateClub: NextPageWithLayout<any> = () => {
     }
 
     // Construct a FormData with all club information
-    let formData = new FormData()
-    formData.append('club_name', data.clubName);
-    formData.append('club_description', data.clubDesc);
-    formData.append('club_token_sym', data.tokenSym.toUpperCase());
-    formData.append('club_image', clubProfileFile);
-    formData.append('user_id', user.user?.uid!);
+    let formData = new FormData();
+    formData.append("club_name", data.clubName);
+    formData.append("club_description", data.clubDesc);
+    formData.append("club_token_sym", data.tokenSym.toUpperCase());
+    formData.append("club_image", clubProfileFile);
+    formData.append("user_id", user.user?.uid!);
 
-    console.log(formData)
+    console.log(formData);
     // Make a post request to /api/create/club endpoint
     const config = {
-      headers: { 'content-type': 'multipart/form-data' },
+      headers: { "content-type": "multipart/form-data" },
     };
 
     try {
-      const club_id = await axios.post('/api/create/club', formData, config).then((response) => response.data).then(data => data.club_id);
+      const club_id = await axios
+        .post("/api/create/club", formData, config)
+        .then((response) => response.data)
+        .then((data) => data.club_id);
       await router.push(`/create/${club_id}/1`);
       setCreateLoading(false);
     } catch (err) {
-      setCreateLoading(false)
+      setCreateLoading(false);
       console.log(err);
     }
   };
 
   return (
-    <Form
-      ref={formRef}
-      onSubmit={handleFormSubmit}
-      initialData={{ email: "eugene@uni.minerva.edu", name: "abc" }}
-      className=" flex flex-col gap-10 w-full justify-center"
-    >
-      {/* Club information */}
-      <div className="flex flex-col items-start gap-4 w-full">
-        <p className="font-bold leading-5 text-sm text-secondary-600 uppercase">
-          Club information
-        </p>
-        <div className="md:flex md:flex-row md:items-start md:gap-8 flex flex-col items-start gap-4 w-full">
-          {/* Image upload field */}
-          <div className="flex flex-col items-start gap-2 w-[94px] md:min-w-[94px]">
-            <p className="text-sm text-gray-800 font-semibold leading-5 md:grow">
-              Profile photo
+    <>
+      {!serverProps.error ? (
+        <Form
+          ref={formRef}
+          onSubmit={handleFormSubmit}
+          initialData={{ email: "eugene@uni.minerva.edu", name: "abc" }}
+          className=" flex flex-col gap-10 w-full justify-center"
+        >
+          {/* Club information */}
+          <div className="flex flex-col items-start gap-4 w-full">
+            <p className="font-bold leading-5 text-sm text-secondary-600 uppercase">
+              Club information
             </p>
-            <ImageUpload setImage={(imageFile: any) => setClubProfileFile(imageFile)}/>
+            <div className="md:flex md:flex-row md:items-start md:gap-8 flex flex-col items-start gap-4 w-full">
+              {/* Image upload field */}
+              <div className="flex flex-col items-start gap-2 w-[94px] md:min-w-[94px]">
+                <p className="text-sm text-gray-800 font-semibold leading-5 md:grow">
+                  Profile photo
+                </p>
+                <ImageUpload
+                  setImage={(imageFile: any) => setClubProfileFile(imageFile)}
+                />
+              </div>
+              <div className="md:flex md:flex-col md:items-start md:gap-4 md:shrink md:min-w-0 flex flex-col items-start gap-4 w-full">
+                <InputField
+                  name="clubName"
+                  label="Club name"
+                  placeholder="e.g. Friends with profits"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setClubName(e.target.value)
+                  }
+                />
+                <InputField
+                  name="clubDesc"
+                  type="text-area"
+                  label="Club description"
+                  placeholder="Something about your investment club"
+                />
+                <InputField
+                  name="tokenSym"
+                  label="Club token symbol"
+                  description="Each member will receive club tokens to represent their ownership of the club."
+                  defaultValue={
+                    clubName &&
+                    clubName.replace(/\s/g, "").slice(0, 6).toUpperCase()
+                  }
+                  className="uppercase"
+                />
+              </div>
+            </div>
           </div>
-          <div className="md:flex md:flex-col md:items-start md:gap-4 md:shrink md:min-w-0 flex flex-col items-start gap-4 w-full">
-            <InputField
-              name="clubName"
-              label="Club name"
-              placeholder="e.g. Friends with profits"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setClubName(e.target.value)
-              }
-            />
-            <InputField
-              name="clubDesc"
-              type="text-area"
-              label="Club description"
-              placeholder="Something about your investment club"
-            />
-            <InputField
-              name="tokenSym"
-              label="Club token symbol"
-              description="Each member will receive club tokens to represent their ownership of the club."
-              defaultValue={clubName && clubName.replace(/\s/g, "").slice(0, 6).toUpperCase()}
-              className="uppercase"
-            />
-          </div>
-        </div>
-      </div>
-      {/* Creation fee */}
-      <div className="flex flex-col items-start">
-        <p className="font-bold leading-5 text-sm text-secondary-600 uppercase mb-1">
-          Creation fee
-        </p>
-        <p className=" text-base leading-6 text-gray-800 mb-4">
-          The creation fee is to set up the club token and enables the club to
-          raise money
-        </p>
+          {/* Creation fee */}
+          <div className="flex flex-col items-start">
+            <p className="font-bold leading-5 text-sm text-secondary-600 uppercase mb-1">
+              Creation fee
+            </p>
+            <p className=" text-base leading-6 text-gray-800 mb-4">
+              The creation fee is to set up the club token and enables the club
+              to raise money
+            </p>
 
-        <FeeEstimate eth={String(process.env.NEXT_PUBLIC_CLUB_DEPOSIT)} usd={12.37} className="w-full"/>
-      </div>
-      {/* Create button */}
-      <div className="flex flex-col items-center gap-3">
-        <p className="text-sm leading-5 text-gray-500">
-          By clicking “Pay and create” you agree to our Terms of Service
-        </p>
-        <Button type="submit" className="w-1/3 min-w-[218px]" loading={createLoading}>
-          <h3>Pay and create</h3>
-        </Button>
-      </div>
-    </Form>
+            <FeeEstimate
+              eth={String(process.env.NEXT_PUBLIC_CLUB_DEPOSIT)}
+              usd={12.37}
+              className="w-full"
+            />
+          </div>
+          {/* Create button */}
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-sm leading-5 text-gray-500">
+              By clicking “Pay and create” you agree to our Terms of Service
+            </p>
+            <Button
+              type="submit"
+              className="w-1/3 min-w-[218px]"
+              loading={createLoading}
+            >
+              <h3>Pay and create</h3>
+            </Button>
+          </div>
+        </Form>
+      ) : (
+        <NotAuthed />
+      )}
+    </>
   );
 };
 

--- a/pages/create/index.tsx
+++ b/pages/create/index.tsx
@@ -83,7 +83,7 @@ const CreateClub: NextPageWithLayout<any> = ({
     formData.append("club_image", clubProfileFile);
     formData.append("user_id", user.user?.uid!);
 
-    console.log(formData);
+    // console.log(formData);
     // Make a post request to /api/create/club endpoint
     const config = {
       headers: { "content-type": "multipart/form-data" },


### PR DESCRIPTION
## PR Overview
This PR solves the page flashing issue when reloading the pages.

Currently, when the user reloads a page, it first shows the unauthed state, and then it will show authed state for each restricted page. It is because the auth state that determines what to render is run after the page is mounted.

The solution is to determine the auth state in the server using getServerSideProps, and then render the page depending on the auth state on the server first

The change involves a few things
1. Every restricted page now has a getServerSideProps, which checks to see if there is a token cookie, if no, returns an error props
2. At each page's render, it will check if the serverSideProps has an error in it. If yes, it will render the NotAuthed component. If no, it will render the page content
3. When logging in and logging out, it will essentially reload the page to tell the server to recheck the auth status and render the right page content